### PR TITLE
Fix add-on translatability

### DIFF
--- a/addon/globalPlugins/nvdaChatGPT/__init__.py
+++ b/addon/globalPlugins/nvdaChatGPT/__init__.py
@@ -114,7 +114,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
             OptionsPanel)
 
     @script(
-        # Translators: Nmae of category in input gesture.
+        # Translators: Name of category in input gesture.
         category=_("Ask chatGPT"),
         # Translators: Description of gesture in input gesture.
         description=_("Ask the meaning of a word to chatGPT"),
@@ -139,6 +139,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
             startMessage="asking the meaning to chatGPT")
 
     @script(
+        # Translators: Name of category in input gesture.
         category=_("Ask chatGPT"),
         description=_("Ask the sentence to chatGPT"),
         gestures=["kb:NVDA+shift+l"]

--- a/addon/globalPlugins/nvdaChatGPT/instructions.py
+++ b/addon/globalPlugins/nvdaChatGPT/instructions.py
@@ -2,7 +2,7 @@
 HOW_TO_GET_KEY = _("""
 1. Go to [here](https://platform.openai.com/account/api-keys)
 2. Login (make an account, if you don't have one)
-3. Press the button "Create new secret key‍"
+3. Press the button "Create new secret key"
 4. Go to nvda - preference - settings - askChatGPT, and put the api key.
 
 You get free credits when you create a new chatGPT account, but it expires in several months.

--- a/addon/globalPlugins/nvdaChatGPT/languages.py
+++ b/addon/globalPlugins/nvdaChatGPT/languages.py
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 # Hard-coded because I wanted the capability to set output language to the one different than the language of nvda
 ASK_MEANING_PROMPT_MODELS = [
     "What is the meaning of {}? Respond in Arabic",

--- a/buildVars.py
+++ b/buildVars.py
@@ -56,7 +56,7 @@ addon_info = {
 # pythonSources = ["addon/globalPlugins/*.py"]
 # For more information on SCons Glob expressions please take a look at:
 # https://scons.org/doc/production/HTML/scons-user/apd.html
-pythonSources = []
+pythonSources = ["addon/globalPlugins/nvdaChatGPT/*.py"]
 
 # Files that contain strings for translation. Usually your python sources
 i18nSources = pythonSources + ["buildVars.py"]


### PR DESCRIPTION
Hello

Here are the fixes so that you get translators comments. This fix contains two parts:

1. Update the Python sources in the `buildVars.py`, as already discussed by e-mail (sorry, I have looked at the wrong line and thought that your update was erroneous)

2. For each non-ASCII Python file, declare the encoding. This is not necessary anymore for Python 3 files, but gettext still requires it as soon as a string contains non ascii character, even if it is not a translatable string.

Note: In `instructions.py`, there seems to be only a "zero width joiner" character at line 6, juste after the word "key". I have considered that it was a mistake and have removed it. If it was not, you may want to put the encoding declaration line in this file too.
